### PR TITLE
Fix CounterViewModel unit tests

### DIFF
--- a/test/viewmodels/counter_view_model_test.dart
+++ b/test/viewmodels/counter_view_model_test.dart
@@ -22,7 +22,7 @@ void main() {
       test(
           'When called 3 times and initialValue is 5, should increment counter value to 8',
           () async {
-        final model = CounterViewModel();
+        final model = CounterViewModel(initialValue: 5);
 
         model.increment();
         model.increment();


### PR DESCRIPTION
The initialValue is 0 as default so we need to set initialValue to 5 for the test to pass.